### PR TITLE
json_normalize call bug fix

### DIFF
--- a/seml/database_utils.py
+++ b/seml/database_utils.py
@@ -48,7 +48,7 @@ def get_results(collection_name, fields=['config', 'result'], to_data_frame=Fals
 
     parsed = [parse_jsonpickle(entry) for entry in results]
     if to_data_frame:
-        parsed = pd.io.jsonpickle.json_normalize(parsed, sep='.')
+        parsed = pd.io.json.json_normalize(parsed, sep='.')
     return parsed
 
 


### PR DESCRIPTION
<!-- 
Thank you for contributing a pull request!
Please name and describe your PR as you would write a
commit message.
-->

### Reference issue
`json_normalize` is called from the wrong sub-package. It should be called from `pandas.io.json` instead of `pandas.io.jsonpickle`. Reference: [Pandas API](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.io.json.json_normalize.html)

### What does this implement/fix?
Fixes calling `json_normalize` function in `database_utils.py`

